### PR TITLE
Update zsh.rs to make zinit and zi use parallel

### DIFF
--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -122,7 +122,7 @@ pub fn run_zinit(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zinit");
 
-    let cmd = format!("source {} && zinit self-update && zinit update --all", zshrc.display(),);
+    let cmd = format!("source {} && zinit self-update && zinit update --all -p", zshrc.display(),);
     ctx.run_type()
         .execute(zsh)
         .args(["-i", "-c", cmd.as_str()])
@@ -137,7 +137,7 @@ pub fn run_zi(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zi");
 
-    let cmd = format!("source {} && zi self-update && zi update --all", zshrc.display(),);
+    let cmd = format!("source {} && zi self-update && zi update --all -p", zshrc.display(),);
     ctx.run_type().execute(zsh).args(["-i", "-c", &cmd]).status_checked()
 }
 


### PR DESCRIPTION
## Standards checklist:

- [Y] The PR title is descriptive.
- [Y] I have read `CONTRIBUTING.md`
- [Y] The code compiles (`cargo build`)
- [ ] The code passes rustfmt (`cargo fmt`)
- [ ] The code passes clippy (`cargo clippy`)
- [Y] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
